### PR TITLE
Improved S3 summary

### DIFF
--- a/R/ee_observations.R
+++ b/R/ee_observations.R
@@ -65,9 +65,9 @@ stop_for_status(data_sources)
 obs_data <- content(data_sources)
 
 required_pages <- ee_paginator(page, obs_data$count)
+all_the_pages <- ceiling(obs_data$count/page_size)
 
-
-if(!quiet)  message(sprintf("Search contains %s observations (downloading %s of %s pages)", obs_data$count, length(required_pages), max(required_pages)))
+if(!quiet)  message(sprintf("Search contains %s observations (downloading %s of %s pages)", obs_data$count, length(required_pages), all_the_pages))
 if(progress) pb <- txtProgressBar(min = 0, max = length(required_pages), style = 3)
 
 

--- a/R/ee_utils.R
+++ b/R/ee_utils.R
@@ -6,11 +6,11 @@
 #'   
 #' @param ... additional arguments
 print.ecoengine <- function(x, ...) {
-cat(sprintf("[Total results]: %s \n", x$results))
+cat(sprintf("[Total results on the server]: %s \n", x$results))
 cat("[Args]: \n")
 suppressWarnings(pretty_lists(x$call))
 cat(sprintf("[Type]: %s \n", x$type))
-cat(sprintf("[Number of results]: %s \n", nrow(x$data)))
+cat(sprintf("[Number of results retrieved]: %s \n", nrow(x$data)))
 }
 
 
@@ -36,6 +36,7 @@ ee_pages <- function(ee, page_size = 25) {
 #'Takes a page range and total number of observations to return the right sequence of pages that need to be crawled.
 #' @param page requested page number or page range. Can also be "all"
 #' @param  total_obs Total number of records available for any search query
+#' @param  page_size Default is \code{25}. Set higher if needed.
 #' @export
 #' @examples \dontrun{
 #' ee_paginator(1, 100)
@@ -45,9 +46,9 @@ ee_pages <- function(ee, page_size = 25) {
 #' # This will return an error since there are only 4 pages per 100 observations
 #' ee_paginator(1:5, 100)
 #' }
-ee_paginator <- function(page, total_obs) {
-        all_pages <- ceiling(total_obs/25)
-        if(total_obs < 25) { req_pages <- 1 }
+ee_paginator <- function(page, total_obs, page_size = 25) {
+        all_pages <- ceiling(total_obs/page_size)
+        if(total_obs < page_size) { req_pages <- 1 }
         if(identical(page, "all")) { req_pages <- seq_along(1: all_pages)}
         if(length(page) == 1 & identical(class(page), "numeric")) { req_pages <- page }
         if(identical(class(page), "integer")) {


### PR DESCRIPTION
In response to @mkoo's question yesterday, I improved the print method to clearly show how many pages are being retrieved and also differentiate what's downloaded on a call as opposed to what's available on the server. With this update, the `ee_observations` calls look like this:

``` coffee
> aves <- ee_observations(clss = "aves")
Search contains 171117 observations (downloading 1 of 6845 pages)
> aves
Total results on the server: 171117 
Args: 
country = United States 
clss = aves 
georeferenced = FALSE 
page_size = 25 
page = 1 
Type: observations 
Number of results retrieved: 25 
```

``` coffee
> aves <- ee_observations(clss = "aves", page = 1:2)
Search contains 171117 observations (downloading 2 of 6845 pages)
> aves
Total results on the server: 171117 
Args: 
country = United States 
clss = aves 
georeferenced = FALSE 
page_size = 25 
page = 1 2 
Type: observations 
Number of results retrieved: 50 
```

With other types of search (e.g. photos)

``` coffee
> z <- ee_photos()
Search contains 43708 photos (downloading 1 of 1 pages )

> z
Total results on the server: 43708 
Args: 
page_size = 25 
georeferenced = 0 
page = 1 
Type: photos 
Number of results retrieved: 25 

```
