### PR TITLE
check if list has length > 0 before assigning name, fixes issue #87

### DIFF
--- a/R/ee_utils.R
+++ b/R/ee_utils.R
@@ -252,7 +252,9 @@ LinearizeNestedList <- function(NList, LinearizeDataFrames=FALSE,
                     names(Element) <- as.character(1:length(Element))
                 Element <- LinearizeNestedList(Element, LinearizeDataFrames,
                                                NameSep, ForceNames)
-                names(Element) <- paste(EName, names(Element), sep=NameSep)
+                if (length(Element)) {
+                  names(Element) <- paste(EName, names(Element), sep=NameSep)
+                }
                 Jump <- length(Element)
                 NList <- c(Before, Element, After)
             }


### PR DESCRIPTION
This resolves issue #87, by making a slight change to LinearizeNestedList().