### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 data/* binary
 src/* text=lf
 R/* text=lf
+*.html linguist-documentation=true


### PR DESCRIPTION
in order to not let GitHub linguist classify the repo as html